### PR TITLE
Added Powerups, PowerupEffects and PowerupPickupArea2D

### DIFF
--- a/src/modules/powerup_system/effects/debug_effect.gd
+++ b/src/modules/powerup_system/effects/debug_effect.gd
@@ -1,0 +1,8 @@
+class_name DebugPowerupEffect extends PowerupEffect
+
+@export var on_apply_message: String = "Hello world!"
+
+
+func apply_effect(event: PowerupPickupEvent) -> void:
+    print("Applied powerup effect on: ", event.entity)
+    print("Apply message: ", on_apply_message)

--- a/src/modules/powerup_system/effects/debug_effect.gd.uid
+++ b/src/modules/powerup_system/effects/debug_effect.gd.uid
@@ -1,0 +1,1 @@
+uid://bhj2mhf52im82

--- a/src/modules/powerup_system/on_powerup_pickup_event.gd
+++ b/src/modules/powerup_system/on_powerup_pickup_event.gd
@@ -1,0 +1,10 @@
+class_name PowerupPickupEvent extends RefCounted
+
+## Event passed to powerups upon being picked up.
+
+## The entity that picked up the powerup (Usually Ball or Paddle)
+var entity: Node
+
+
+func _init(p_entity: Node) -> void:
+    entity = p_entity

--- a/src/modules/powerup_system/on_powerup_pickup_event.gd.uid
+++ b/src/modules/powerup_system/on_powerup_pickup_event.gd.uid
@@ -1,0 +1,1 @@
+uid://d0nrtn8itbo4f

--- a/src/modules/powerup_system/powerup.gd
+++ b/src/modules/powerup_system/powerup.gd
@@ -1,0 +1,21 @@
+class_name Powerup extends Resource
+
+enum PowerupType { BALL, PADDLE }
+
+## Internal identifier
+@export var powerup_identifier: StringName
+## Powerup display name for use in UI
+@export var powerup_display_name: StringName
+## Texture used for the powerup in-game
+@export var powerup_texture: Texture2D
+## Additional scene automatically instantiated on the powerup used for VFX
+@export var powerup_vfx: PackedScene
+## Decides if the powerup can be picked up by the Ball or Paddle
+@export var powerup_type: PowerupType = PowerupType.BALL
+## Effects applied on pickup
+@export var powerup_effects: Array[PowerupEffect] = []
+
+
+func pick_up(pickup_event: PowerupPickupEvent) -> void:
+    for effect in powerup_effects:
+        effect.apply_effect(pickup_event)

--- a/src/modules/powerup_system/powerup.gd.uid
+++ b/src/modules/powerup_system/powerup.gd.uid
@@ -1,0 +1,1 @@
+uid://dwayqr5vvtmex

--- a/src/modules/powerup_system/powerup_effect.gd
+++ b/src/modules/powerup_system/powerup_effect.gd
@@ -1,0 +1,5 @@
+class_name PowerupEffect extends Resource
+
+
+func apply_effect(_event: PowerupPickupEvent) -> void:
+    pass

--- a/src/modules/powerup_system/powerup_effect.gd.uid
+++ b/src/modules/powerup_system/powerup_effect.gd.uid
@@ -1,0 +1,1 @@
+uid://tvxig6akjiqd

--- a/src/modules/powerup_system/powerup_pickup_area_2d.gd
+++ b/src/modules/powerup_system/powerup_pickup_area_2d.gd
@@ -1,0 +1,56 @@
+class_name PowerupPickupArea2D extends Area2D
+
+signal picked_up
+
+@export var powerup_resource: Powerup
+@export var collider_size: Vector2 = Vector2(25, 25)
+
+
+func _ready() -> void:
+    assert(powerup_resource, "Powerup must be set.")
+
+    # Hardcoded layer
+    collision_layer = 5
+
+    # Set collision mask to be affected by either the Paddle or the Ball
+    collision_mask = 1 if powerup_resource.powerup_type == Powerup.PowerupType.BALL else 2
+
+    body_entered.connect(func(body: Node2D): pick_up(body))
+
+    setup_collision_shape()
+    setup_visuals()
+
+
+func _process(_delta: float) -> void:
+    if Input.is_action_just_pressed("ui_accept"):
+        pick_up(self)
+
+
+func setup_collision_shape() -> void:
+    var collision_shape := CollisionShape2D.new()
+    var rectangle_shape := RectangleShape2D.new()
+
+    rectangle_shape.size = collider_size
+
+    collision_shape.shape = RectangleShape2D.new()
+
+    add_child(collision_shape)
+
+
+func setup_visuals() -> void:
+    if powerup_resource.powerup_vfx:
+        var vfx_node: Node = powerup_resource.powerup_vfx.instantiate()
+        add_child(vfx_node)
+
+    if powerup_resource.powerup_texture:
+        var sprite := Sprite2D.new()
+        sprite.texture = powerup_resource.powerup_texture
+        add_child(sprite)
+        sprite.position = sprite.global_scale / 2.0
+
+
+func pick_up(body: Node2D) -> void:
+    var event := PowerupPickupEvent.new(body)
+    powerup_resource.pick_up(event)
+    picked_up.emit()
+    queue_free()

--- a/src/modules/powerup_system/powerup_pickup_area_2d.gd
+++ b/src/modules/powerup_system/powerup_pickup_area_2d.gd
@@ -6,6 +6,10 @@ signal picked_up
 @export var collider_size: Vector2 = Vector2(25, 25)
 
 
+func _init(p_powerup_resource: Powerup = null) -> void:
+    powerup_resource = p_powerup_resource
+
+
 func _ready() -> void:
     assert(powerup_resource, "Powerup must be set.")
 

--- a/src/modules/powerup_system/powerup_pickup_area_2d.gd.uid
+++ b/src/modules/powerup_system/powerup_pickup_area_2d.gd.uid
@@ -1,0 +1,1 @@
+uid://c8gu46i3klubl

--- a/src/modules/powerup_system/powerups/debug_powerup.tres
+++ b/src/modules/powerup_system/powerups/debug_powerup.tres
@@ -1,0 +1,22 @@
+[gd_resource type="Resource" script_class="Powerup" load_steps=6 format=3 uid="uid://ba75c4p8ngrid"]
+
+[ext_resource type="Script" uid="uid://dwayqr5vvtmex" path="res://modules/powerup_system/powerup.gd" id="1_q5bvd"]
+[ext_resource type="Script" uid="uid://tvxig6akjiqd" path="res://modules/powerup_system/powerup_effect.gd" id="1_sp4yf"]
+[ext_resource type="Script" uid="uid://bhj2mhf52im82" path="res://modules/powerup_system/effects/debug_effect.gd" id="2_n6p8e"]
+
+[sub_resource type="Resource" id="Resource_vlugl"]
+script = ExtResource("2_n6p8e")
+on_apply_message = "Hello world!"
+metadata/_custom_type_script = "uid://bhj2mhf52im82"
+
+[sub_resource type="PlaceholderTexture2D" id="PlaceholderTexture2D_n6p8e"]
+size = Vector2(16, 16)
+
+[resource]
+script = ExtResource("1_q5bvd")
+powerup_identifier = &"debug"
+powerup_display_name = &"Debug"
+powerup_texture = SubResource("PlaceholderTexture2D_n6p8e")
+powerup_type = 0
+powerup_effects = Array[ExtResource("1_sp4yf")]([SubResource("Resource_vlugl")])
+metadata/_custom_type_script = "uid://dwayqr5vvtmex"


### PR DESCRIPTION
Powerup is a resource that defines all the necessary data about a powerup, including its' effects and visuals.

PowerupPickupArea2D is an Area2D class that is the actual powerup spawned in the stage. The Powerup resource defines if the powerup can be picked up by the Paddle or the Ball, and what kind of visuals the powerup has. (Both through a sprite and a custom scene)

A Powerup has an array of PowerupEffects, which is where we can define what the powerups actually do. Here, the effects get their context from a PowerupPickupEvent, which currently only holds a reference to the entity that picked up the powerup.

PowerupEffects are very open in how they are implemented, and one could, for example, make an effect that increases the game score, splits the ball into multiple balls with random velocities/directions, etc.