### PR TITLE
Game Manager now can spawn PowerupPickupAreas

### DIFF
--- a/src/modules/game_manager/game_manager.gd
+++ b/src/modules/game_manager/game_manager.gd
@@ -1,16 +1,42 @@
 class_name GameManager
 extends Node2D
 
+@export_category("Packed Scenes")
 @export var ball_scene: PackedScene
 @export var paddle_scene: PackedScene
 
+@export_category("Powerups")
+@export var powerup_pool: Array[Powerup] = []
+@export var powerup_cooldown_duration: float = 10.0
+
 @onready var viewport_size: Vector2 = get_viewport().get_visible_rect().size
+
+var powerup_cooldown: float = 0.0
 
 
 func _ready() -> void:
     handle_player_spawn()
     handle_opponent_spawn()
     handle_ball_spawn()
+
+
+func _physics_process(delta: float) -> void:
+    powerup_cooldown += delta
+    if powerup_cooldown >= powerup_cooldown_duration:
+        spawn_powerup()
+        powerup_cooldown = 0
+
+
+func spawn_powerup() -> void:
+    var chosen_powerup: Powerup = powerup_pool.pick_random()
+    var powerup_pickup_area := PowerupPickupArea2D.new(chosen_powerup)
+    var screen_rect := get_viewport().get_visible_rect()
+    var viable_rect := screen_rect.grow(-100)
+    powerup_pickup_area.position = (
+        viable_rect.position
+        + Vector2(randf_range(0, viable_rect.size.x), randf_range(0, viable_rect.size.y))
+    )
+    self.add_child(powerup_pickup_area)
 
 
 func handle_opponent_spawn():

--- a/src/modules/powerup_system/powerup_pickup_area_2d.gd
+++ b/src/modules/powerup_system/powerup_pickup_area_2d.gd
@@ -17,7 +17,7 @@ func _ready() -> void:
     set_collision_layer_value(5, true)
 
     # Set collision mask to be affected by either the Paddle or the Ball
-    var mask := 1 if powerup_resource.powerup_type == Powerup.PowerupType.BALL else 2
+    var mask := 1 if powerup_resource.powerup_type == Powerup.PowerupType.PADDLE else 2
     set_collision_mask_value(mask, true)
 
     body_entered.connect(func(body: Node2D): pick_up(body))


### PR DESCRIPTION
GameManager now has a `_physics_process` function to spawn `PowerupPickupAreas`. Also, modified `PowerupPickupArea` because the Paddle/Ball collision was reversed.